### PR TITLE
Send correct MIME type instead of text/plain

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -180,6 +180,7 @@ buffer."
      ((not (imp-buffer-enabled-p buffer)) (imp--private proc buffer-name))
      ((and (not (string= file "./")) buffer-dir)
       (let* ((full-file-name (expand-file-name file buffer-dir))
+             (mime-type (httpd-get-mime (file-name-extension full-file-name)))
              (live-buffer (cl-remove-if-not
                            (lambda (buf) (equal full-file-name (buffer-file-name buf)))
                            (imp--buffer-list))))
@@ -188,9 +189,9 @@ buffer."
             (with-temp-buffer
               (insert-buffer-substring (cl-first live-buffer))
               (if (imp--should-not-cache-p path)
-                  (httpd-send-header proc "text/plain" 200
+                  (httpd-send-header proc mime-type 200
                                      :Cache-Control "no-cache")
-                (httpd-send-header proc "text/plain" 200
+                (httpd-send-header proc mime-type 200
                                    :Cache-Control
                                    "max-age=60, must-revalidate")))
           (httpd-send-file proc full-file-name req))))


### PR DESCRIPTION
When another file (e.g. a CSS stylesheet) is referenced from an HTML file, `impatient-mode` serves it with a hardcoded `Content-Type: text/plain`. This causes problems in browsers; for example, Firefox ignores CSS files that aren't sent as `text/css`.

This commit makes `impatient-mode` determine the MIME type to send based on the extension of the requested file.
