### PR TITLE
Don't htmlize mhtml-mode buffers

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -70,7 +70,8 @@
   "If non-nil, buffer has been modified but not sent to clients.")
 
 (defvar imp-default-user-filters
-  '((html-mode . nil)
+  '((mhtml-mode . nil)
+    (html-mode . nil)
     (web-mode  . nil))
   "Alist indicating which filter should be used for which modes.")
 


### PR DESCRIPTION
Emacs 26.1 ships with new derived mode of `html-mode`: `mhtml-mode` is now the default mode for html files.