### PR TITLE
Solve package-lint/check-doc/byte-compiler warnings

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -10,18 +10,18 @@
 ;;; Commentary:
 
 ;; impatient-mode is a minor mode that publishes the live buffer
-;; through the local simple-httpd server under /imp/live/<buffer-name>/. To
-;; unpublish a buffer, toggle impatient-mode off.
+;; through the local simple-httpd server under /imp/live/<buffer-name>/.
+;; To unpublish a buffer, toggle impatient-mode off.
 
 ;; Start the simple-httpd server (`httpd-start') and visit /imp/ on
-;; the local server. There will be a listing of all the buffers that
-;; currently have impatient-mode enabled. This is likely to be found
+;; the local server.  There will be a listing of all the buffers that
+;; currently have impatient-mode enabled.  This is likely to be found
 ;; here:
 
 ;;   http://localhost:8080/imp/
 
 ;; Except for html-mode buffers, buffers will be prettied up with
-;; htmlize before being sent to clients. This can be toggled at any
+;; htmlize before being sent to clients.  This can be toggled at any
 ;; time with `imp-toggle-htmlize'.
 
 ;; Because html-mode buffers are sent raw, you can use impatient-mode
@@ -29,8 +29,8 @@
 ;; primary motivation of this mode.
 
 ;; To receive updates the browser issues a long poll on the client
-;; waiting for the buffer to change -- server push. The response
-;; happens in an `after-change-functions' hook. Buffers that do not
+;; waiting for the buffer to change -- server push.  The response
+;; happens in an `after-change-functions' hook.  Buffers that do not
 ;; run these hooks will not be displayed live to clients.
 
 ;;; Code:

--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -40,7 +40,7 @@
 (require 'simple-httpd)
 (require 'htmlize)
 
-(defgroup impatient-mode nil
+(defgroup impatient nil
   "Serve buffers live over HTTP."
   :group 'comm)
 
@@ -78,7 +78,7 @@
 ;;;###autoload
 (define-minor-mode impatient-mode
   "Serves the buffer live over HTTP."
-  :group 'impatient-mode
+  :group 'impatient
   :lighter " imp"
   :keymap impatient-mode-map
   (if (not impatient-mode)

--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -48,8 +48,8 @@
   "Keymap for impatient-mode.")
 
 (defvar impatient-mode-delay nil
-  "The delay in seconds between a keypress and the buffer being
-   reloaded in the browser.  Set to nil for no delay")
+  "The delay in seconds between a keypress and the browser reload.
+Set to nil for no delay")
 
 (defvar-local imp--idle-timer nil
   "A timer that goes off after `impatient-mode-delay' seconds of inactivity")
@@ -93,7 +93,7 @@
   "Location of data files needed by impatient-mode.")
 
 (defun imp-set-user-filter (fn)
-  "Sets a FN as user-defined filter for this buffer.
+  "Set a FN as user-defined filter for this buffer.
 FUNCTION should accept one argument, the buffer to be filtered,
 and will be evaluated with the output buffer set as the current
 buffer."
@@ -103,7 +103,7 @@ buffer."
   (imp--notify-clients))
 
 (defun imp-remove-user-filter ()
-  "Sets the user-defined filter for this buffer to the default."
+  "Set the user-defined filter for this buffer to the default."
   (interactive)
   (let ((lookup (assoc major-mode imp-default-user-filters)))
     (if lookup
@@ -113,7 +113,7 @@ buffer."
   (imp--notify-clients))
 
 (defun imp-htmlize-filter (buffer)
-  "Htmlization of buffers before sending to clients."
+  "Htmlize BUFFER before sending to clients."
   (let ((html-buffer (save-match-data (htmlize-buffer buffer))))
     (insert-buffer-substring html-buffer)
     (kill-buffer html-buffer)))
@@ -127,7 +127,7 @@ buffer."
 
 (defun imp-visit-buffer (&optional arg)
   "Visit the current buffer in a browser.
-If given a prefix argument, visit the buffer listing instead."
+If given a prefix ARG, visit the buffer listing instead."
   (interactive "P")
   (unless (process-status "httpd")
     (httpd-start))
@@ -139,15 +139,15 @@ If given a prefix argument, visit the buffer listing instead."
     (browse-url url)))
 
 (defun imp-buffer-enabled-p (buffer)
-  "Return t if buffer has impatient-mode enabled."
+  "Return t if BUFFER has impatient-mode enabled."
   (and buffer (with-current-buffer (get-buffer buffer) impatient-mode)))
 
 (defun imp--buffer-list ()
-  "List of all buffers with impatient-mode enabled"
+  "List of all buffers with impatient-mode enabled."
   (cl-remove-if-not 'imp-buffer-enabled-p (buffer-list)))
 
 (defun imp--should-not-cache-p (path)
-  "True if the path should be stamped with a no-cache header"
+  "True if the PATH should be stamped with a no-cache header."
   (let ((mime-type (httpd-get-mime (file-name-extension path))))
     (member mime-type '("text/css" "text/html" "text/xml"
                         "text/plain" "text/javascript"))))
@@ -181,7 +181,7 @@ If given a prefix argument, visit the buffer listing instead."
                (format "Buffer %s is private or doesn't exist." buffer-name)))
 
 (defun httpd/imp/live (proc path _query req)
-  "Serve up the shim that lets us watch a buffer change"
+  "Serve up the shim that lets us watch a buffer change."
   (let* ((index (expand-file-name "index.html" imp-shim-root))
          (decoded (url-unhex-string path))
          (parts (cdr (split-string decoded "/")))
@@ -281,7 +281,7 @@ If given a prefix argument, visit the buffer listing instead."
     (imp--update-buffer)))
 
 (defun imp--after-timeout ()
-  "Executes after `impatient-mode-delay' seconds of idleness"
+  "Execute after `impatient-mode-delay' seconds of idleness."
   (when imp--buffer-dirty-p
     (imp--update-buffer))
   (imp--start-idle-timer))

--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -44,9 +44,6 @@
   "Serve buffers live over HTTP."
   :group 'comm)
 
-(defvar impatient-mode-map (make-sparse-keymap)
-  "Keymap for impatient-mode.")
-
 (defvar impatient-mode-delay nil
   "The delay in seconds between a keypress and the browser reload.
 Set to nil for no delay")
@@ -74,6 +71,9 @@ Set to nil for no delay")
     (html-mode . nil)
     (web-mode  . nil))
   "Alist indicating which filter should be used for which modes.")
+
+(defvar impatient-mode-map (make-sparse-keymap)
+  "Keymap for impatient-mode.")
 
 ;;;###autoload
 (define-minor-mode impatient-mode

--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -44,9 +44,11 @@
   "Serve buffers live over HTTP."
   :group 'comm)
 
-(defvar impatient-mode-delay nil
+(defcustom impatient-mode-delay nil
   "The delay in seconds between a keypress and the browser reload.
-Set to nil for no delay")
+Set to nil for no delay"
+  :group 'impatient
+  :type 'boolean)
 
 (defvar-local imp--idle-timer nil
   "A timer that goes off after `impatient-mode-delay' seconds of inactivity")

--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Brian Taylor <el.wubo@gmail.com>
 ;; Version: 1.1
 ;; URL: https://github.com/netguy204/imp.el
-;; Package-Requires: ((cl-lib "0.3") (simple-httpd "1.5.0") (htmlize "1.40"))
+;; Package-Requires: ((emacs "24.1") (simple-httpd "1.5.0") (htmlize "1.40"))
 
 ;;; Commentary:
 

--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -50,6 +50,13 @@ Set to nil for no delay"
   :group 'impatient
   :type 'boolean)
 
+(defcustom imp-default-user-filters '((mhtml-mode . nil)
+                                      (html-mode . nil)
+                                      (web-mode  . nil))
+  "Alist indicating which filter should be used for which modes."
+  :group 'impatient
+  :type 'sexp)
+
 (defvar-local imp--idle-timer nil
   "A timer that goes off after `impatient-mode-delay' seconds of inactivity")
 
@@ -67,12 +74,6 @@ Set to nil for no delay"
 
 (defvar-local imp--buffer-dirty-p nil
   "If non-nil, buffer has been modified but not sent to clients.")
-
-(defvar imp-default-user-filters
-  '((mhtml-mode . nil)
-    (html-mode . nil)
-    (web-mode  . nil))
-  "Alist indicating which filter should be used for which modes.")
 
 (defvar impatient-mode-map (make-sparse-keymap)
   "Keymap for impatient-mode.")

--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -92,13 +92,13 @@
 (defvar imp-shim-root (file-name-directory load-file-name)
   "Location of data files needed by impatient-mode.")
 
-(defun imp-set-user-filter (function)
-  "Sets a user-defined filter for this buffer.
+(defun imp-set-user-filter (fn)
+  "Sets a FN as user-defined filter for this buffer.
 FUNCTION should accept one argument, the buffer to be filtered,
 and will be evaluated with the output buffer set as the current
 buffer."
   (interactive "aCustom filter: ")
-  (setq imp-user-filter function)
+  (setq imp-user-filter fn)
   (cl-incf imp-last-state)
   (imp--notify-clients))
 

--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Brian Taylor <el.wubo@gmail.com>
 ;; Version: 1.1
 ;; URL: https://github.com/netguy204/imp.el
-;; Package-Requires: ((emacs "24.1") (simple-httpd "1.5.0") (htmlize "1.40"))
+;; Package-Requires: ((emacs "24.3") (simple-httpd "1.5.0") (htmlize "1.40"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
Hi!
I found this package, I fix some pacakge-lint/check-doc/byte-compiler
warnings.

## before
```elisp
 impatien…     1  60 warning         You should depend on (emacs "24") if you need lexical-binding. (emacs-lisp-package)
 impatien…    13     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 impatien…    17     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 impatien…    18     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 impatien…    24     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 impatien…    32     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 impatien…    33     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 impatien…    43   1 error           Customization groups should not end in "-mode" unless that name would conflict with their parent group. (emacs-lisp-package)
 impatien…    51     warning         Second line should not have indentation (emacs-lisp-checkdoc)
 impatien…    51     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 impatien…    54   1 error           "imp--idle-timer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    54   2 error           You should depend on (emacs "24.3") if you need `defvar-local'. (emacs-lisp-package)
 impatien…    57   1 error           "imp-user-filter" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    57   2 error           You should depend on (emacs "24.3") if you need `defvar-local'. (emacs-lisp-package)
 impatien…    60   1 error           "imp-client-list" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    60   2 error           You should depend on (emacs "24.3") if you need `defvar-local'. (emacs-lisp-package)
 impatien…    63   1 error           "imp-last-state" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    63   2 error           You should depend on (emacs "24.3") if you need `defvar-local'. (emacs-lisp-package)
 impatien…    66   1 error           "imp-related-files" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    66   2 error           You should depend on (emacs "24.3") if you need `defvar-local'. (emacs-lisp-package)
 impatien…    69   1 error           "imp--buffer-dirty-p" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    69   2 error           You should depend on (emacs "24.3") if you need `defvar-local'. (emacs-lisp-package)
 impatien…    72   1 error           "imp-default-user-filters" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    92   1 error           "imp-shim-root" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    95   1 error           "imp-set-user-filter" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…    96     warning         Probably "Sets" should be imperative "Set" (emacs-lisp-checkdoc)
 impatie…   105   1 error           "imp-remove-user-filter" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   106     warning         Probably "Sets" should be imperative "Set" (emacs-lisp-checkdoc)
 impatie…   115   1 error           "imp-htmlize-filter" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   116     warning         Argument ‘buffer’ should appear (as BUFFER) in the doc string (emacs-lisp-checkdoc)
 impatie…   121   1 error           "imp-toggle-htmlize" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   128   1 error           "imp-visit-buffer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   129     warning         Argument ‘arg’ should appear (as ARG) in the doc string (emacs-lisp-checkdoc)
 impatie…   141   1 error           "imp-buffer-enabled-p" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   142     warning         Argument ‘buffer’ should appear (as BUFFER) in the doc string (emacs-lisp-checkdoc)
 impatie…   145   1 error           "imp--buffer-list" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   146     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 impatie…   149   1 error           "imp--should-not-cache-p" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   150     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 impatie…   150     warning         Argument ‘path’ should appear (as PATH) in the doc string (emacs-lisp-checkdoc)
 impatie…   155   1 error           "httpd/imp/static" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   155   1 error           `httpd/imp/static' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 impatie…   156     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 impatie…   163   1 error           "imp-serve-buffer-list" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   164     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 impatie…   179   1 error           "imp--private" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   180     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   183   1 error           "httpd/imp/live" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   183   1 error           `httpd/imp/live' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 impatie…   184     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 impatie…   184     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 impatie…   184     warning         Probably "lets" should be imperative "let" (emacs-lisp-checkdoc)
 impatie…   218   1 error           "httpd/imp" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   218   1 error           `httpd/imp' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 impatie…   219     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   224   1 error           "imp--send-state" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   225     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   236   1 error           "imp--send-state-ignore-errors" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   237     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   241   1 error           "imp--notify-clients" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   242     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   245   1 error           "imp--cleanup-timer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   251   1 error           "imp--start-idle-timer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   276   1 error           "imp--on-change" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   283   1 error           "imp--after-timeout" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   284     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 impatie…   284     warning         Probably "Executes" should be imperative "Execute" (emacs-lisp-checkdoc)
 impatie…   289   1 error           "imp--update-buffer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   302   1 error           "httpd/imp/buffer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   302   1 error           `httpd/imp/buffer' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 impatie…   303     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
```

## after
```elisp
 impatien…    53   1 error           "imp-default-user-filters" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    60   1 error           "imp--idle-timer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    63   1 error           "imp-user-filter" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    66   1 error           "imp-client-list" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    69   1 error           "imp-last-state" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    72   1 error           "imp-related-files" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    75   1 error           "imp--buffer-dirty-p" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatien…    95   1 error           "imp-shim-root" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…    98   1 error           "imp-set-user-filter" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   108   1 error           "imp-remove-user-filter" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   118   1 error           "imp-htmlize-filter" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   124   1 error           "imp-toggle-htmlize" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   131   1 error           "imp-visit-buffer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   144   1 error           "imp-buffer-enabled-p" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   148   1 error           "imp--buffer-list" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   152   1 error           "imp--should-not-cache-p" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   158   1 error           "httpd/imp/static" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   158   1 error           `httpd/imp/static' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 impatie…   159     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 impatie…   166   1 error           "imp-serve-buffer-list" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   167     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 impatie…   182   1 error           "imp--private" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   183     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   186   1 error           "httpd/imp/live" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   186   1 error           `httpd/imp/live' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 impatie…   187     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 impatie…   187     warning         Probably "lets" should be imperative "let" (emacs-lisp-checkdoc)
 impatie…   221   1 error           "httpd/imp" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   221   1 error           `httpd/imp' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 impatie…   222     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   227   1 error           "imp--send-state" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   228     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   239   1 error           "imp--send-state-ignore-errors" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   240     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   244   1 error           "imp--notify-clients" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   245     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 impatie…   248   1 error           "imp--cleanup-timer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   254   1 error           "imp--start-idle-timer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   279   1 error           "imp--on-change" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   286   1 error           "imp--after-timeout" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   292   1 error           "imp--update-buffer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   305   1 error           "httpd/imp/buffer" doesn't start with package's prefix "impatient". (emacs-lisp-package)
 impatie…   305   1 error           `httpd/imp/buffer' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 impatie…   306     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
```