### PR TITLE
Filter function outputs filtered string to default-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The original editing buffer is passed along the user filter as a parameter, whic
   (let ((count 
      (with-current-buffer buffer
            (count-words-region (point-min) (point-max)))))
-    (princ (format  "<html><body>%d</body></html>" count) (current-buffer))))
+    (princ (format "<html><body>%d</body></html>" count) (current-buffer))))
 ```
 
 You can remove user filters with `imp-remove-user-filter`, which will reset the default `htmlize`. For reference, this is how the default user function is defined:
@@ -85,7 +85,7 @@ You can remove user filters with `imp-remove-user-filter`, which will reset the 
 (defun default-user-filter (buffer)
   "Htmlization of buffers before sending to clients."
   (let ((html-buffer (save-match-data (htmlize-buffer buffer))))
-    (insert-buffer-substring html-buffer)
+    (princ (with-current-buffer html-buffer (buffer-string)))
     (kill-buffer html-buffer)))
 ```
 

--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -115,7 +115,7 @@ buffer."
 (defun imp-htmlize-filter (buffer)
   "Htmlization of buffers before sending to clients."
   (let ((html-buffer (save-match-data (htmlize-buffer buffer))))
-    (insert-buffer-substring html-buffer)
+    (princ (with-current-buffer html-buffer (buffer-string)))
     (kill-buffer html-buffer)))
 
 (defun imp-toggle-htmlize ()
@@ -226,12 +226,13 @@ If given a prefix argument, visit the buffer listing instead."
         (user-filter imp-user-filter)
         (buffer (current-buffer)))
     (with-temp-buffer
-      (if user-filter
-          (funcall user-filter buffer)
-        (insert-buffer-substring buffer))
-      (httpd-send-header proc "text/html" 200
-                         :Cache-Control "no-cache"
-                         :X-Imp-Count id))))
+      (let ((standard-output (current-buffer)))
+        (if user-filter
+            (funcall user-filter buffer)
+          (insert-buffer-substring buffer))
+        (httpd-send-header proc "text/html" 200
+                           :Cache-Control "no-cache"
+                           :X-Imp-Count id)))))
 
 (defun imp--send-state-ignore-errors (proc)
   (condition-case _


### PR DESCRIPTION
README says filter function should use `princ`.

> Except for html-mode buffers, buffer contents will be run through a user-defined filter. The default user filter is htmlize, but you can set your own with imp-set-user-filter. The user filter is nothing but a regular elisp function. Here's how you would define a basic filter:

```elisp
(defun my-filter (_)
  (princ "<html><body>test</body></html>" (current-buffer)))
```

> The original editing buffer is passed along the user filter as a parameter, which we didn't use in the previous example, but which is demonstrated in the following example:

```elisp
(defun my-filter (buffer)
  (let ((count 
     (with-current-buffer buffer
           (count-words-region (point-min) (point-max)))))
    (princ (format  "<html><body>%d</body></html>" count) (current-buffer))))
```

But `imp-htmlize-filter` do `insert` filtered contents.

Since the user is unlikely to notice that the current buffer has
changed due to a side effect, I am concerned that INSERT will
rewrite the current buffer.

Like the function in README, the filter function outputs a string
by `princ` and I think it would be better to capture it by changing
the `standard-output`.