### PR TITLE
imp-visit-buffer uses httpd-host if set

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -136,7 +136,7 @@ If given a prefix ARG, visit the buffer listing instead."
     (httpd-start))
   (unless impatient-mode
     (impatient-mode))
-  (let ((url (format "http://%s:%d/imp/" (system-name) httpd-port)))
+  (let ((url (format "http://%s:%d/imp/" (or httpd-host (system-name)) httpd-port)))
     (unless arg
       (setq url (format "%slive/%s/" url (url-hexify-string (buffer-name)))))
     (browse-url url)))


### PR DESCRIPTION
If `httpd-host` is set, prefer that value.

This allows me to use a local network name, e.g. `foo.lan` rather than just `foo`, which allows me to view these buffers on non-localhost devices in the same network.