### PR TITLE
Use localhost when appropriate in imp-visit-buffer

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -136,7 +136,16 @@ If given a prefix ARG, visit the buffer listing instead."
     (httpd-start))
   (unless impatient-mode
     (impatient-mode))
-  (let ((url (format "http://%s:%d/imp/" (system-name) httpd-port)))
+  (let* ((proc (get-process "httpd"))
+         (proc-info (process-contact proc t))
+         (raw-host (plist-get proc-info :host))
+         (host (if (member raw-host
+                           '(nil local "127.0.0.1" "::1" "0.0.0.0" "::"))
+                   "localhost"
+                 raw-host))
+         (local-addr (plist-get proc-info :local))
+         (port (aref local-addr (1- (length local-addr))))
+         (url (format "http://%s:%d/imp/" host port)))
     (unless arg
       (setq url (format "%slive/%s/" url (url-hexify-string (buffer-name)))))
     (browse-url url)))


### PR DESCRIPTION
By default, simple-httpd starts listening on localhost.  If `(system-name)` is not a name that resolves to 127.0.0.1 or ::1, which is the case here on my macOS system, the connection will fail since simple-httpd is only listening on the loopback address.  For example, if `(system-name)` returns "foo.example.com", the URL `http://foo.example.com:8080/imp/` will fail because foo.example.com is actually resolving to my LAN address, not the loopback address, whereas simple-httpd is only listening on loopback.

To avoid this problem, we interrogate the server socket set up by simple-httpd to see what `:host` it was created with (see `make-network-process`), identify when that is one of the values that means "localhost", and just use the name "localhost" in those cases.  We'll also use "localhost" when you bind to 0.0.0.0 or ::.

Since I had already pulled back the `process-contact` info for simple-httpd's socket, I went ahead and pulled the port out of that as well.

I decided to use `process-contact` instead of `httpd-host` and `httpd-port` because, if you have somehow managed to change `httpd-host` and/or `httpd-port` since starting simple-httpd, we'll still pick up the actual, correct values in use by the server that's running right now.