### PR TITLE
Allow slash in buffer name

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,13 +33,23 @@
 </iframe>
 
 <script type="text/javascript">
-var buffer = window.location.pathname.split('/')[3];
+
+var parseBufferName = function(path) {
+  const re = /^\/imp\/\w+\/(.*)\/$/;
+  var match = re.exec(path);
+  if (!match || !match[1])
+     return null;
+
+  return decodeURIComponent(match[1]);
+};
+
+var buffer = parseBufferName(window.location.pathname);
 var max_period = 60000;
 var min_period = 1000;
 var next_period = min_period;
 var alpha = 1.2;
 var current_id = '-1';
-$('head').append($('<title/>').text(decodeURI(buffer)));
+$('head').append($('<title/>').text(buffer));
 
 var nextTimeout = function() {
   var next = next_period;
@@ -80,7 +90,7 @@ var setIframe = function(count, newText) {
 };
 
 var refresh = function() {
-  var url = "/imp/buffer/" + buffer;
+  var url = "/imp/buffer/" + encodeURIComponent(buffer) + "/";
 
   var gotData = function(data, status, xhr) {
     resetTimeout();


### PR DESCRIPTION
I have buffer names like:

- `impatient-mode:/…/README.md`
- `emacs:/…/unique/path/file.el`
- `emacs:/…/also/file.el`

These buffers could not be displayed by `impatient-mode` due to how the buffer name was passed around in the URL. This fixes the encoding/decoding/parsing of the URL to allow for such buffer names.